### PR TITLE
[fix] fix app.jsx

### DIFF
--- a/resources/js/app.jsx
+++ b/resources/js/app.jsx
@@ -9,7 +9,6 @@ import { Provider } from 'react-redux';
 import store from './Store/store'; // Redux storeのインポート
 import ThemeComponent from './Components/Theme/ThemeComponent';
 import ThreadComponent from './Components/Thread/ThreadComponent';
-import Welcome from './Pages/Welcome';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
@@ -19,18 +18,21 @@ createInertiaApp({
     setup({ el, App, props }) {
         const root = createRoot(el);
 
-        root.render(
-            <Provider store={store}> {/* ReduxのProviderでアプリケーションをラップ */}
-                <Router>
-                    <Routes>
-                        <Route path="*" element={<App {...props} />} />
-                        <Route path="/group" element={<Welcome />} />
-                        <Route path="/group/:groupId" element={<ThemeComponent />} />
-                        <Route path="/theme/:thmeId" element={<ThreadComponent />} />
-                    </Routes>
-                </Router>
-            </Provider>
-        );
+        // Welcome.jsxを動的にインポート
+        import('./Pages/Welcome').then((Welcome) => {
+            root.render(
+                <Provider store={store}> {/* ReduxのProviderでアプリケーションをラップ */}
+                    <Router>
+                        <Routes>
+                            <Route path="*" element={<App {...props} />} />
+                            <Route path="/group" element={<Welcome.default />} />
+                            <Route path="/group/:groupId" element={<ThemeComponent />} />
+                            <Route path="/theme/:thmeId" element={<ThreadComponent />} />
+                        </Routes>
+                    </Router>
+                </Provider>
+            );
+        });
     },
     progress: {
         color: '#4B5563',


### PR DESCRIPTION
@F0gr1 
もし問題なら戻してもおけだけど、本番はこれで動いていないっぽい。



以下chatGPTの回答 :

app.jsxのコードを確認しました。問題の原因は、Welcome.jsxを静的にインポートしていることにあります。Viteでは同じモジュールを静的・動的に混在してインポートすることは許可されていません。

app.jsxの中でWelcome.jsxを動的にインポートするように変更してみてください。以下は修正例です：

```
// app.jsx
import './bootstrap';
import '../css/app.css';
import { createRoot } from 'react-dom/client';
import { createInertiaApp } from '@inertiajs/react';
import { resolvePageComponent } from 'laravel-vite-plugin/inertia-helpers';
import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
import { Provider } from 'react-redux';
import store from './Store/store'; // Redux storeのインポート
import ThemeComponent from './Components/Theme/ThemeComponent';
import ThreadComponent from './Components/Thread/ThreadComponent';

const appName = import.meta.env.VITE_APP_NAME || 'Laravel';

createInertiaApp({
    title: (title) => `${title} - ${appName}`,
    resolve: (name) => resolvePageComponent(`./Pages/${name}.jsx`, import.meta.glob('./Pages/**/*.jsx')),
    setup({ el, App, props }) {
        const root = createRoot(el);

        // Welcome.jsxを動的にインポート
        import('./Pages/Welcome').then((Welcome) => {
            root.render(
                <Provider store={store}> {/* ReduxのProviderでアプリケーションをラップ */}
                    <Router>
                        <Routes>
                            <Route path="*" element={<App {...props} />} />
                            <Route path="/group" element={<Welcome.default />} />
                            <Route path="/group/:groupId" element={<ThemeComponent />} />
                            <Route path="/theme/:thmeId" element={<ThreadComponent />} />
                        </Routes>
                    </Router>
                </Provider>
            );
        });
    },
    progress: {
        color: '#4B5563',
    },
});
```

この変更により、Welcome.jsxが動的にインポートされ、静的なインポートが排除されます。修正が完了したら、再度ビルドしてデプロイしてみてください。





